### PR TITLE
Поддержка атрибута transform в заголовке тега svg

### DIFF
--- a/src/js/svg-map.js
+++ b/src/js/svg-map.js
@@ -153,7 +153,7 @@ var SvgMap = function (options) {
 
     var mouseDown = function (e) {
         root.state = STATE_CLICK;
-    }
+    };
 
     var mouseUp = function () {
         if (root.state == STATE_CLICK) {
@@ -164,7 +164,7 @@ var SvgMap = function (options) {
 
         root.state = STATE_INITIAL;
         root.toolTip.style.visibility = 'visible';
-    }
+    };
 
     var mouseMove = function (e) {
         switch(root.state) {
@@ -266,7 +266,7 @@ var SvgMap = function (options) {
             return false;
         }
         root.svg.setAttribute('viewBox', box.x+' '+box.y+' '+box.width+' '+box.height);
-    }
+    };
 
     var mouseOver = function (e) {
         if (root.showTip) {
@@ -308,9 +308,6 @@ var SvgMap = function (options) {
      */
     var adaptViewBox = function (svg) {
         root.box = svg.getBBox();
-
-        // TODO: why svg is turned upside down?!
-        svg.setAttribute('transform', 'scale(1, -1)');
 
         svg.setAttribute('viewBox', root.box.x + ' ' + root.box.y + ' ' + root.box.width + ' ' + root.box.height);
         root.state = STATE_INITIAL;

--- a/src/js/svg-map.js
+++ b/src/js/svg-map.js
@@ -309,6 +309,9 @@ var SvgMap = function (options) {
     var adaptViewBox = function (svg) {
         root.box = svg.getBBox();
 
+        // TODO: Seems like there are turned over data in russia.php
+        svg.setAttribute('transform', 'scale(1, -1)');
+        
         svg.setAttribute('viewBox', root.box.x + ' ' + root.box.y + ' ' + root.box.width + ' ' + root.box.height);
         root.state = STATE_INITIAL;
     };


### PR DESCRIPTION
Mozila Firefox не поддерживает в SVG заголовке атрибут transform который задаётся в svg-map.js
https://developer.mozilla.org/ru/docs/Web/SVG/Attribute/transform

Его поддержка планируется в SVG 2
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/transform

Поэтому виджет и не работает в Mozila Firefox